### PR TITLE
Check if suggestions are empty and skip if they are.

### DIFF
--- a/src/Plugin/views/area/SpellCheck.php
+++ b/src/Plugin/views/area/SpellCheck.php
@@ -89,6 +89,10 @@ class SpellCheck extends AreaPluginBase {
         if (!empty($extra_data['spellcheck'])) {
           // Loop over the suggestions and print them as links.
           foreach ($extra_data['spellcheck'] as $suggestion) {
+            // Check if the suggestion itself is empty and skip if it is.
+            if (empty($suggestion)) {
+              continue;
+            }
             // If we have a match within our filters we add the suggestion.
             if ($filter = $this->getFilterMatch($suggestion)) {
               // Merge the query parameters.


### PR DESCRIPTION
Applicable for Solr search.

For some reason, when using this module with `search_api_solr` and `search_api_solr_multilingual`, if you search for a term that doesn't return any results and doesn't return any suggestions, an error is produced.

Has to do with `getFilterMatch()` and `$suggestion[0]`. This fix checks if the suggestion is empty and continues if it is.